### PR TITLE
build: include README in built dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,10 @@ class BDistWheelCommand(BDistWheelCommandBase):
         return python, abi, plat
 
 
-long_description = """\
-redshift_connector is a Pure-Python interface to the Amazon Redshift. """
+# read the contents of your README file
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
 exec(open("redshift_connector/version.py").read())
 
 setup(
@@ -87,6 +89,7 @@ setup(
     version=__version__,
     description="Redshift interface library",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Amazon Web Services",
     author_email="redshift-drivers@amazon.com",
     url="https://github.com/aws/amazon-redshift-python-driver",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modifies `setup.py` to include README in built distribution file so it can render on pypi

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `python3 setup.py` succeeds
- [ ] My code follows the code style of this project
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
