### PR TITLE
doc: Fix errors in connection parameter table. Add missing parameters…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,6 @@ Basic Example
     # Connects to Redshift cluster using AWS credentials
     conn = redshift_connector.connect(
         host='examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com',
-        port=5439,
         database='dev',
         user='awsuser',
         password='my_password'
@@ -132,7 +131,7 @@ Connection Parameters
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | idp_response_timeout    | Int. The timeout for retrieving SAML assertion from IdP                                    | 120           | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
-| idp_port                | Int. The listen port IdP will send the SAML assertion to                                   | 7890          | No       |
+| listen_port                | Int. The listen port IdP will send the SAML assertion to                                | 7890          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | log_level               | Int. The level of logging enabled, increasing in granularity (values [0,4] are valid)      | 0             | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
@@ -142,14 +141,22 @@ Connection Parameters
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | idp_tenant              | String. The IdP tenant                                                                     | None          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
-| credential_provider     | String. The IdP that will be used for authenticating with Amazon Redshift.                 | None          | No       |
+| credentials_provider    | String. The IdP that will be used for authenticating with Amazon Redshift.                 | None          | No       |
 |                         | 'OktaCredentialsProvider', 'AzureCredentialsProvider', 'BrowserAzureCredentialsProvider',  |               |          |
 |                         | 'PingCredentialsProvider', 'BrowserSamlCredentialsProvider', and 'AdfsCredentialsProvider' |               |          |
-|                         | are supported.                                                                             |               |          |
+|                         | are supported                                                                              |               |          |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | cluster_identifier      | String. The cluster identifier of the Amazon Redshift Cluster                              | None          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | db_user                 | String. The user ID to use with Amazon Redshift                                            | None          | No       |
++-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
+| db_groups               | String. A comma-separated list of existing database group names that the DbUser joins for  | None          | No       |
+|                         | the current session                                                                        |               |          |
++-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
+| auto_create             | Bool. Indicates whether the user should be created if they do not exist                    | False         | No       |
++-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
+| allow_db_user_override  | Bool. `True` specifies the driver uses the DbUser value from the SAML assertion while      | False         | No       |
+|                         | `False` indicates the value in the DbUser connection parameter is used                     |               |          |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | login_url               | String. The SSO Url for the IdP                                                            | None          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
@@ -161,7 +168,7 @@ Connection Parameters
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 | region                  | String. The AWS region where the cluster is located                                        | None          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
-| app_name                | String. The name of the IdP application used for authentication.                           | None          | No       |
+| app_name                | String. The name of the IdP application used for authentication                            | None          | No       |
 +-------------------------+--------------------------------------------------------------------------------------------+---------------+----------+
 
 


### PR DESCRIPTION
… to table

Updates README connection parameters table

## Description
Addresses README connection parameter documentation errors

- Fixes idp_port to be listen_port
- Fixes crednetial_provider to be credentials_provider
- Adds forgotten parameters dp_groups, auto_create, allow_db_user_override


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `python3 setup.py` succeeds
- [ ] My code follows the code style of this project
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
