### PR TITLE
Utilize request sessions for ping identity provider plugin

### DIFF
--- a/redshift_connector/plugin/ping_credentials_provider.py
+++ b/redshift_connector/plugin/ping_credentials_provider.py
@@ -31,102 +31,104 @@ class PingCredentialsProvider(SamlCredentialsProvider):
 
         self.check_required_parameters()
 
-        if self.partner_sp_id is None:
-            self.partner_sp_id = "urn%3Aamazon%3Awebservices"
+        with requests.Session() as session:
 
-        url: str = "https://{host}:{port}/idp/startSSO.ping?PartnerSpId={sp_id}".format(
-            host=self.idp_host, port=str(self.idpPort), sp_id=self.partner_sp_id
-        )
-        try:
-            response: "requests.Response" = requests.get(url, verify=self.do_verify_ssl_cert())
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            if "response" in vars():
-                _logger.debug("get_saml_assertion https response: {}".format(response.text))  # type: ignore
-            else:
-                _logger.debug("get_saml_assertion could not receive https response due to an error")
-            _logger.error("Request for SAML assertion when refreshing credentials was unsuccessful. {}".format(str(e)))
-            raise InterfaceError(e)
-        except requests.exceptions.Timeout as e:
-            _logger.error("A timeout occurred when requesting SAML assertion")
-            raise InterfaceError(e)
-        except requests.exceptions.TooManyRedirects as e:
-            _logger.error(
-                "A error occurred when requesting SAML assertion to refresh credentials. "
-                "Verify RedshiftProperties are correct"
+            if self.partner_sp_id is None:
+                self.partner_sp_id = "urn%3Aamazon%3Awebservices"
+
+            url: str = "https://{host}:{port}/idp/startSSO.ping?PartnerSpId={sp_id}".format(
+                host=self.idp_host, port=str(self.idpPort), sp_id=self.partner_sp_id
             )
-            raise InterfaceError(e)
-        except requests.exceptions.RequestException as e:
-            _logger.error("A unknown error occurred when requesting SAML assertion to refresh credentials")
-            raise InterfaceError(e)
+            try:
+                response: "requests.Response" = session.get(url, verify=self.do_verify_ssl_cert())
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                if "response" in vars():
+                    _logger.debug("get_saml_assertion https response: {}".format(response.text))  # type: ignore
+                else:
+                    _logger.debug("get_saml_assertion could not receive https response due to an error")
+                _logger.error("Request for SAML assertion when refreshing credentials was unsuccessful. {}".format(str(e)))
+                raise InterfaceError(e)
+            except requests.exceptions.Timeout as e:
+                _logger.error("A timeout occurred when requesting SAML assertion")
+                raise InterfaceError(e)
+            except requests.exceptions.TooManyRedirects as e:
+                _logger.error(
+                    "A error occurred when requesting SAML assertion to refresh credentials. "
+                    "Verify RedshiftProperties are correct"
+                )
+                raise InterfaceError(e)
+            except requests.exceptions.RequestException as e:
+                _logger.error("A unknown error occurred when requesting SAML assertion to refresh credentials")
+                raise InterfaceError(e)
 
-        try:
-            soup = bs4.BeautifulSoup(response.text)
-        except Exception as e:
-            _logger.error("An error occurred while parsing response: {}".format(str(e)))
-            raise InterfaceError(e)
+            try:
+                soup = bs4.BeautifulSoup(response.text)
+            except Exception as e:
+                _logger.error("An error occurred while parsing response: {}".format(str(e)))
+                raise InterfaceError(e)
 
-        payload: typing.Dict[str, typing.Optional[str]] = {}
-        username: bool = False
-        pwd: bool = False
+            payload: typing.Dict[str, typing.Optional[str]] = {}
+            username: bool = False
+            pwd: bool = False
 
-        for inputtag in soup.find_all(re.compile("(INPUT|input)")):
-            name: str = inputtag.get("name", "")
-            id: str = inputtag.get("id", "")
-            value: str = inputtag.get("value", "")
-
-            if username is False and self.is_text(inputtag) and id == "username":
-                payload[name] = self.user_name
-                username = True
-            elif self.is_password(inputtag) and ("pass" in name):
-                if pwd is True:
-                    raise InterfaceError("Duplicate password fields on login page.")
-                payload[name] = self.password
-                pwd = True
-            elif name != "":
-                payload[name] = value
-
-        if username is False:
             for inputtag in soup.find_all(re.compile("(INPUT|input)")):
-                name = inputtag.get("name", "")
-                if self.is_text(inputtag) and ("user" in name or "email" in name):
+                name: str = inputtag.get("name", "")
+                id: str = inputtag.get("id", "")
+                value: str = inputtag.get("value", "")
+
+                if username is False and self.is_text(inputtag) and id == "username":
                     payload[name] = self.user_name
                     username = True
+                elif self.is_password(inputtag) and ("pass" in name):
+                    if pwd is True:
+                        raise InterfaceError("Duplicate password fields on login page.")
+                    payload[name] = self.password
+                    pwd = True
+                elif name != "":
+                    payload[name] = value
 
-        if (username is False) or (pwd is False):
-            raise InterfaceError("Failed to parse login form.")
+            if username is False:
+                for inputtag in soup.find_all(re.compile("(INPUT|input)")):
+                    name = inputtag.get("name", "")
+                    if self.is_text(inputtag) and ("user" in name or "email" in name):
+                        payload[name] = self.user_name
+                        username = True
 
-        action: typing.Optional[str] = self.get_form_action(soup)
-        if action and action.startswith("/"):
-            url = "https://{host}:{port}{action}".format(host=self.idp_host, port=str(self.idpPort), action=action)
-        try:
-            response = requests.post(url, data=payload, verify=self.do_verify_ssl_cert())
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            _logger.error("Request to refresh credentials was unsuccessful. {}".format(str(e)))
-            raise InterfaceError(e)
-        except requests.exceptions.Timeout as e:
-            _logger.error("A timeout occurred when attempting to refresh credentials")
-            raise InterfaceError(e)
-        except requests.exceptions.TooManyRedirects as e:
-            _logger.error("A error occurred when refreshing credentials. Verify RedshiftProperties are correct")
-            raise InterfaceError(e)
-        except requests.exceptions.RequestException as e:
-            _logger.error("A unknown error occurred when refreshing credentials")
-            raise InterfaceError(e)
+            if (username is False) or (pwd is False):
+                raise InterfaceError("Failed to parse login form.")
 
-        try:
-            soup = bs4.BeautifulSoup(response.text)
-        except Exception as e:
-            _logger.error("An error occurred while parsing SAML response: {}".format(str(e)))
-            raise InterfaceError(e)
+            action: typing.Optional[str] = self.get_form_action(soup)
+            if action and action.startswith("/"):
+                url = "https://{host}:{port}{action}".format(host=self.idp_host, port=str(self.idpPort), action=action)
+            try:
+                response = session.post(url, data=payload, verify=self.do_verify_ssl_cert())
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                _logger.error("Request to refresh credentials was unsuccessful. {}".format(str(e)))
+                raise InterfaceError(e)
+            except requests.exceptions.Timeout as e:
+                _logger.error("A timeout occurred when attempting to refresh credentials")
+                raise InterfaceError(e)
+            except requests.exceptions.TooManyRedirects as e:
+                _logger.error("A error occurred when refreshing credentials. Verify RedshiftProperties are correct")
+                raise InterfaceError(e)
+            except requests.exceptions.RequestException as e:
+                _logger.error("A unknown error occurred when refreshing credentials")
+                raise InterfaceError(e)
 
-        assertion: str = ""
-        for inputtag in soup.find_all("input"):
-            if inputtag.get("name") == "SAMLResponse":
-                assertion = inputtag.get("value")
+            try:
+                soup = bs4.BeautifulSoup(response.text)
+            except Exception as e:
+                _logger.error("An error occurred while parsing SAML response: {}".format(str(e)))
+                raise InterfaceError(e)
 
-        if assertion == "":
-            raise InterfaceError("Failed to retrieve SAMLAssertion.")
+            assertion: str = ""
+            for inputtag in soup.find_all("input"):
+                if inputtag.get("name") == "SAMLResponse":
+                    assertion = inputtag.get("value")
 
-        return assertion
+            if assertion == "":
+                raise InterfaceError("Failed to retrieve SAMLAssertion.")
+
+            return assertion


### PR DESCRIPTION
## Description
Changes to the PingCredentialsProvider to utilize `requests` Sessions when making HTTP requests to Ping host.

## Motivation and Context
Some Ping implementations require cookies when making requests and those cookies need to be used when making subsequent requests to retrieve SAML. 

## Testing
- Unit tests passed. 
- Tested in a live environment with Ping and Redshift cluster.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Local run of `python3 setup.py` succeeds
- [x] My code follows the code style of this project
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
