### PR TITLE
makes credentials expiration UTC/localtime aware

### DIFF
--- a/redshift_connector/credentials_holder.py
+++ b/redshift_connector/credentials_holder.py
@@ -1,9 +1,14 @@
 import datetime
+import logging
+import time
 import typing
 from abc import ABC, abstractmethod
 
 if typing.TYPE_CHECKING:
     import boto3  # type: ignore
+
+
+_logger: logging.Logger = logging.getLogger(__name__)
 
 
 class ABCCredentialsHolder(ABC):
@@ -145,7 +150,9 @@ class CredentialsHolder(ABCCredentialsHolder):
         return self.expiration
 
     def is_expired(self: "CredentialsHolder") -> bool:
-        return datetime.datetime.now() > self.expiration.replace(tzinfo=None)
+        _logger.debug("Credentials will expire at {} (UTC)".format(self.expiration))
+
+        return datetime.datetime.now(datetime.timezone.utc) > self.expiration
 
     class IamMetadata:
         """

--- a/redshift_connector/credentials_holder.py
+++ b/redshift_connector/credentials_holder.py
@@ -62,7 +62,11 @@ class AWSDirectCredentialsHolder(ABCAWSCredentialsHolder):
     """
 
     def __init__(
-        self, access_key_id: str, secret_access_key: str, session_token: typing.Optional[str], session: "boto3.Session"
+        self,
+        access_key_id: str,
+        secret_access_key: str,
+        session_token: typing.Optional[str],
+        session: "boto3.Session",
     ):
         super().__init__(session)
         self.access_key_id: str = access_key_id
@@ -70,7 +74,9 @@ class AWSDirectCredentialsHolder(ABCAWSCredentialsHolder):
         self.session_token: typing.Optional[str] = session_token
         self._session: "boto3.Session" = session
 
-    def get_session_credentials(self: "AWSDirectCredentialsHolder") -> typing.Dict[str, str]:
+    def get_session_credentials(
+        self: "AWSDirectCredentialsHolder",
+    ) -> typing.Dict[str, str]:
         creds: typing.Dict[str, str] = {
             "aws_access_key_id": self.access_key_id,
             "aws_secret_access_key": self.secret_access_key,
@@ -91,7 +97,9 @@ class AWSProfileCredentialsHolder(ABCAWSCredentialsHolder):
         super().__init__(session)
         self.profile = profile
 
-    def get_session_credentials(self: "AWSProfileCredentialsHolder") -> typing.Dict[str, str]:
+    def get_session_credentials(
+        self: "AWSProfileCredentialsHolder",
+    ) -> typing.Dict[str, str]:
         return {"profile": self.profile}
 
 
@@ -100,7 +108,9 @@ class CredentialsHolder(ABCCredentialsHolder):
     credentials class used to store credentials and metadata from SAML assertion.
     """
 
-    def __init__(self: "CredentialsHolder", credentials: typing.Dict[str, typing.Any]) -> None:
+    def __init__(
+        self: "CredentialsHolder", credentials: typing.Dict[str, typing.Any]
+    ) -> None:
         self.metadata: "CredentialsHolder.IamMetadata" = CredentialsHolder.IamMetadata()
         self.credentials: typing.Dict[str, typing.Any] = credentials
         self.expiration: "datetime.datetime" = credentials["Expiration"]
@@ -154,7 +164,9 @@ class CredentialsHolder(ABCCredentialsHolder):
         def get_auto_create(self: "CredentialsHolder.IamMetadata") -> bool:
             return self.auto_create
 
-        def set_auto_create(self: "CredentialsHolder.IamMetadata", auto_create: str) -> None:
+        def set_auto_create(
+            self: "CredentialsHolder.IamMetadata", auto_create: str
+        ) -> None:
             if auto_create.lower() == "true":
                 self.auto_create = True
             else:
@@ -166,28 +178,40 @@ class CredentialsHolder(ABCCredentialsHolder):
         def set_db_user(self: "CredentialsHolder.IamMetadata", db_user: str) -> None:
             self.db_user = db_user
 
-        def get_saml_db_user(self: "CredentialsHolder.IamMetadata") -> typing.Optional[str]:
+        def get_saml_db_user(
+            self: "CredentialsHolder.IamMetadata",
+        ) -> typing.Optional[str]:
             return self.saml_db_user
 
-        def set_saml_db_user(self: "CredentialsHolder.IamMetadata", saml_db_user: str) -> None:
+        def set_saml_db_user(
+            self: "CredentialsHolder.IamMetadata", saml_db_user: str
+        ) -> None:
             self.saml_db_user = saml_db_user
 
-        def get_profile_db_user(self: "CredentialsHolder.IamMetadata") -> typing.Optional[str]:
+        def get_profile_db_user(
+            self: "CredentialsHolder.IamMetadata",
+        ) -> typing.Optional[str]:
             return self.profile_db_user
 
-        def set_profile_db_user(self: "CredentialsHolder.IamMetadata", profile_db_user: str) -> None:
+        def set_profile_db_user(
+            self: "CredentialsHolder.IamMetadata", profile_db_user: str
+        ) -> None:
             self.profile_db_user = profile_db_user
 
         def get_db_groups(self: "CredentialsHolder.IamMetadata") -> typing.List[str]:
             return self.db_groups
 
-        def set_db_groups(self: "CredentialsHolder.IamMetadata", db_groups: typing.List[str]) -> None:
+        def set_db_groups(
+            self: "CredentialsHolder.IamMetadata", db_groups: typing.List[str]
+        ) -> None:
             self.db_groups = db_groups
 
         def get_allow_db_user_override(self: "CredentialsHolder.IamMetadata") -> bool:
             return self.allow_db_user_override
 
-        def set_allow_db_user_override(self: "CredentialsHolder.IamMetadata", allow_db_user_override: str) -> None:
+        def set_allow_db_user_override(
+            self: "CredentialsHolder.IamMetadata", allow_db_user_override: str
+        ) -> None:
             if allow_db_user_override.lower() == "true":
                 self.allow_db_user_override = True
             else:
@@ -196,7 +220,9 @@ class CredentialsHolder(ABCCredentialsHolder):
         def get_force_lowercase(self: "CredentialsHolder.IamMetadata") -> bool:
             return self.force_lowercase
 
-        def set_force_lowercase(self: "CredentialsHolder.IamMetadata", force_lowercase: str) -> None:
+        def set_force_lowercase(
+            self: "CredentialsHolder.IamMetadata", force_lowercase: str
+        ) -> None:
             if force_lowercase.lower() == "true":
                 self.force_lowercase = True
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ addopts =
     --cov-report term-missing
     --cov-report html:build/coverage
     --cov-report xml:build/coverage/coverage.xml
-    test
+testpaths=test

--- a/test/unit/test_credentials_holder.py
+++ b/test/unit/test_credentials_holder.py
@@ -85,22 +85,19 @@ def test_aws_profile_credentials_holder_get_session_credentials():
 
 
 @pytest.mark.parametrize(
-    "expiration",
+    "expiration_delta",
     [
-        datetime.datetime.now(datetime.timezone.utc)
-        - datetime.timedelta(hours=3),  # expired 3 hrs ago
-        datetime.datetime.now(datetime.timezone.utc)
-        - datetime.timedelta(days=1),  # expired 1 day ago
-        datetime.datetime.now(datetime.timezone.utc)
-        - datetime.timedelta(weeks=1),  # expired 1 week ago
+        datetime.timedelta(hours=3),  # expired 3 hrs ago
+        datetime.timedelta(days=1),  # expired 1 day ago
+        datetime.timedelta(weeks=1),  # expired 1 week ago
     ],
 )
-def test_is_expired_true(expiration):
+def test_is_expired_true(expiration_delta):
     credentials: typing.Dict[str, typing.Any] = {
         "AccessKeyId": "something",
         "SecretAccessKey": "secret",
         "SessionToken": "fornow",
-        "Expiration": expiration,
+        "Expiration": datetime.datetime.now(datetime.timezone.utc) - expiration_delta,
     }
 
     obj: CredentialsHolder = CredentialsHolder(credentials=credentials)
@@ -109,26 +106,23 @@ def test_is_expired_true(expiration):
 
 
 @pytest.mark.parametrize(
-    "expiration",
+    "expiration_delta",
     [
-        datetime.datetime.now(datetime.timezone.utc)
-        + datetime.timedelta(minutes=1),  # expired 1 minute ago
-        datetime.datetime.now(datetime.timezone.utc)
-        + datetime.timedelta(hours=3),  # expired 3 hrs ago
-        datetime.datetime.now(datetime.timezone.utc)
-        + datetime.timedelta(days=1),  # expired 1 day ago
-        datetime.datetime.now(datetime.timezone.utc)
-        + datetime.timedelta(weeks=1),  # expired 1 week ago
+        datetime.timedelta(minutes=2),  # expired 1 minute ago
+        datetime.timedelta(hours=3),  # expired 3 hrs ago
+        datetime.timedelta(days=1),  # expired 1 day ago
+        datetime.timedelta(weeks=1),  # expired 1 week ago
     ],
 )
-def test_is_expired_false(expiration):
+def test_is_expired_false(expiration_delta):
     credentials: typing.Dict[str, typing.Any] = {
         "AccessKeyId": "something",
         "SecretAccessKey": "secret",
         "SessionToken": "fornow",
-        "Expiration": expiration,
+        "Expiration": datetime.datetime.now(datetime.timezone.utc) + expiration_delta,
     }
 
     obj: CredentialsHolder = CredentialsHolder(credentials=credentials)
 
     assert obj.is_expired() == False
+    

--- a/test/unit/test_credentials_holder.py
+++ b/test/unit/test_credentials_holder.py
@@ -14,7 +14,10 @@ from redshift_connector.credentials_holder import (
 def test_aws_direct_credentials_holder_should_have_session():
     mocked_session: MagicMock = MagicMock()
     obj: AWSDirectCredentialsHolder = AWSDirectCredentialsHolder(
-        access_key_id="something", secret_access_key="secret", session_token="fornow", session=mocked_session
+        access_key_id="something",
+        secret_access_key="secret",
+        session_token="fornow",
+        session=mocked_session,
     )
 
     assert isinstance(obj, ABCAWSCredentialsHolder)
@@ -23,9 +26,19 @@ def test_aws_direct_credentials_holder_should_have_session():
     assert obj.get_boto_session() == mocked_session
 
 
-valid_aws_direct_credential_params: typing.List[typing.Dict[str, typing.Optional[str]]] = [
-    {"access_key_id": "something", "secret_access_key": "secret", "session_token": "fornow"},
-    {"access_key_id": "something", "secret_access_key": "secret", "session_token": None},
+valid_aws_direct_credential_params: typing.List[
+    typing.Dict[str, typing.Optional[str]]
+] = [
+    {
+        "access_key_id": "something",
+        "secret_access_key": "secret",
+        "session_token": "fornow",
+    },
+    {
+        "access_key_id": "something",
+        "secret_access_key": "secret",
+        "session_token": None,
+    },
 ]
 
 
@@ -47,7 +60,9 @@ def test_aws_direct_credentials_holder_get_session_credentials(input):
 
 def test_aws_profile_credentials_holder_should_have_session():
     mocked_session: MagicMock = MagicMock()
-    obj: AWSProfileCredentialsHolder = AWSProfileCredentialsHolder(profile="myprofile", session=mocked_session)
+    obj: AWSProfileCredentialsHolder = AWSProfileCredentialsHolder(
+        profile="myprofile", session=mocked_session
+    )
 
     assert isinstance(obj, ABCAWSCredentialsHolder)
     assert hasattr(obj, "get_boto_session")
@@ -57,7 +72,9 @@ def test_aws_profile_credentials_holder_should_have_session():
 
 def test_aws_profile_credentials_holder_get_session_credentials():
     profile_val: str = "myprofile"
-    obj: AWSProfileCredentialsHolder = AWSProfileCredentialsHolder(profile=profile_val, session=MagicMock())
+    obj: AWSProfileCredentialsHolder = AWSProfileCredentialsHolder(
+        profile=profile_val, session=MagicMock()
+    )
 
     ret_value = obj.get_session_credentials()
     assert len(ret_value) == 1


### PR DESCRIPTION
Connecting to a Redshift cluster with Okta as the IdP was causing the `login_url` to be opened twice. The original issue is the fact that STS credentials expiration datetime was set in UTC and checked against local time (which is UTC+2 in my case). Local time was always an hour ahead (UTC+2 - STS session length of 1 hour) in my case and credentials were considered `expired` as soon as they were created.

Additionally fixes test collection by changing the `setup.cfg` - this could potentially be a different PR.

Logs look like this
```
2021-07-15 13:55:08,636 - redshift_connector.credentials_holder - DEBUG - Credentials will expire at 2021-07-15 12:55:08+00:00 (UTC), local time is 2021-07-15 13:55:08.636606+02:00.
Difference between local time and UTC time is 2 hours.
```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Local time was always an hour ahead (UTC+2 - STS session length of 1 hour) in my case and credentials were considered `expired` as soon as they were created. Fixes #40 

## Testing
Executed the following script in the CEST (`Europe/Amsterdam`) to verify that `login_url` was opened only once

```
import redshift_connector


conn = redshift_connector.connect(
    iam=True,
    ssl=True,
    host="REDSHIFT_ENDPOINT",
    port=5439,
    database="DB_NAME",
    db_user="IDP_USERNAME",
    region="AWS_REGION",
    cluster_identifier="CLUSTER_NAME",
    login_url="IDP_LOGIN_URL",
    credentials_provider="BrowserSamlCredentialsProvider",
    user="",
    password=""
)

cursor: redshift_connector.Cursor = conn.cursor()
cursor.execute("select current_user")

result = cursor.fetchone()
print(result)
```

It would be great to have unit tests for this change but I am unsure how to 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.
Running `pytest test/unit` produces `391 passed, 3 skipped, 18 errors in 7.90s`. Ones that failed did so because of `configparser.NoSectionError: No section: 'ci-cluster'`

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
