### PR TITLE
fix: Data manipulation issues in saml_credentials_provider

### DIFF
--- a/redshift_connector/plugin/saml_credentials_provider.py
+++ b/redshift_connector/plugin/saml_credentials_provider.py
@@ -100,6 +100,7 @@ class SamlCredentialsProvider(ABC):
                     role: str = ""
                     provider: str = ""
                     for arn in arns:
+                        arn = arn.strip() # remove trailing or leading whitespace
                         if role_pattern.match(arn):
                             role = arn
                         if provider_pattern.match(arn):

--- a/redshift_connector/plugin/saml_credentials_provider.py
+++ b/redshift_connector/plugin/saml_credentials_provider.py
@@ -213,7 +213,7 @@ class SamlCredentialsProvider(ABC):
             for attr in attrs:
                 name: str = attr.attrs["Name"]
                 values: typing.Any = attr.findAll("{}AttributeValue".format(SAML_RESP_NAMESPACES[namespace_used_idx]))
-                if len(values) == 0:
+                if len(values) == 0 or not values[0].contents:
                     # Ignore empty-valued attributes.
                     continue
                 value: str = values[0].contents[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Description

### issue #55 fix
Some minor changes to data manipulation to fix bugs that I have encountered when using `redshift_connector`. 

Adding `arn.strip()`, because in some cases, when the list of arns is created in the line `value.contents[0].split(",")`, `value.contents[0]` is a comma delimited string, and there can be whitespace before or after that string. For example
```
value.contents[0] = "my_arn_1, my_arn_2"
arns = value.contents[0].split(",")
print(arns)
>> ["my_arn_1", " my_arn_2"]
```
The second arn has a leading whitespace, which causes it to fail a regex formatting check. Adding strip lets us remove the unwanted whitespace.

### issue #56 fix
The current check only confirms that values exists, but the existence of values doesn't guarantee that contents attribute will have a non-empty list. So this check fails when `values[0].contents = []` 
```
                if len(values) == 0:
                    # Ignore empty-valued attributes.
                    continue
                value: str = values[0].contents[0]
```
Changing this to `if len(values) == 0 or not values[0].contents:` adds an extra `or` check to also ensure that there


## Motivation and Context
This fix solves the following issues:

issue #55 
issue #56 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Both changes were tested by running a simple script to create a connection and run a query.
```
import redshift_connector

gdp_conn = redshift_connector.connect(
    iam=True,
    database="mydb",
    cluster_identifier="mycluster",
    credentials_provider='OktaCredentialsProvider',
    user="my.email@domain.com",
    password="mypassword",
    idp_host="myidphost",
    app_id="myapp/id",
    region="us-east-1",
    role_arn="arn:aws:iam::999999999999:role/My_Role",
)

with gdp_conn.cursor() as c:
    c.execute("select top 1 * from pg_user") 
    result = c.fetchall()

    print(result)
```
> (['dbuser', 100, True, True, False, '********', None, None],)

(note: all string values have been replaced with dummy values as they contain sensitive information)

Backwards compatibility was not explicitly tested, but we can be sure that these changes won't do anything to harm the existing code:

`arn = arn.split()` will only remove whitespace. If executions did not previously introduce whitespace, the value of `arn` will not be changed.
`if len(values) == 0 or not values[0].contents:` will only change the logic if values[0].contents is empty (and if it is empty, it will throw an error anyway)
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] I have run all unit tests using `pytest test/unit` and they are passing.
Note that I did not add any unit tests, as I felt the scope of the changes were so minor that they did not warrant an additional unit test. 

Note, that unit tests failed 18 tests, however these tests also appear to be failing on the master branch of the repository, so the code changes introduced did not cause the unit tests to fail. (this could just be an environment issue on my end, but this seems okay to me)

![Screen Shot 2021-09-15 at 2 00 04 PM](https://user-images.githubusercontent.com/51718761/133508851-cf28deb7-0909-4c6e-a474-d6a3870a0b32.png)

<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.



## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
