### PR TITLE
fix(connection): load system certificates

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -561,6 +561,7 @@ class Connection:
 
                     ssl_context: SSLContext = SSLContext()
                     ssl_context.verify_mode = CERT_REQUIRED
+                    ssl_context.load_default_certs()
                     ssl_context.load_verify_locations(path)
 
                     # Int32(8) - Message length, including self.


### PR DESCRIPTION
## Description
The change will include system certificates, in additional to the redshift's certificate that is being loaded explicitly. 

## Motivation and Context
We are proxying redshift connection via our product, and the used certificate is signed by Let's Encrypt, so when our customers are using the python connector they are unable connect via our proxy to their redshift's warehouse. 

## Testing
1. Testing connectivity and query via our proxy
```
import redshift_connector
import sys
conn = redshift_connector.connect(
        user="xyz",
        host="host.satoricyber.info",
        database="demo",
        port=5439,
        password='abc',
        sslmode="verify-full",
        )
rows = conn.run("select 1")
print (rows)

```
> python3 satori.py 
([1],)

2. Testing connectivity and query directly connecting redshift.

```
import redshift_connector
import sys
conn = redshift_connector.connect(
        user="xyz",
        host="cluster-abc.us-east-2.redshift.amazonaws.com",
        database="demo",
        port=5439,
        password='abc',
        sslmode="verify-full",
        )
rows = conn.run("select 1")
print (rows)
```
> python3 redshift.py
([1],)

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x ] Local run of `./build.sh` succeeds
- [x ] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x ] I have run all unit tests using `pytest test/unit` and they are passing.
Note, failed tests are identical to master tests failures. 

`===================================================================================================================================== short test summary info =====================================================================================================================================
FAILED test/unit/test_iam_helper.py::test_set_iam_properties_enforce_setting_compatibility[joint_params25] - pkg_resources.DistributionNotFound: The 'boto3' distribution was not found and is required by the application
FAILED test/unit/test_iam_helper.py::test_set_cluster_credentials_caches_credentials - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_set_cluster_credentials_honors_iam_disable_cache - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_set_cluster_credentials_ignores_cache_when_disabled - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_set_cluster_credentials_uses_cache_if_possible - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_set_cluster_credentials_refreshes_stale_credentials - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_set_iam_properties_use_redshift_auth_profile_calls_read_auth_profile - pkg_resources.DistributionNotFound: The 'boto3' distribution was not found and is required by the application
FAILED test/unit/test_iam_helper.py::test_set_iam_properties_redshift_auth_profile_does_override - pkg_resources.DistributionNotFound: The 'boto3' distribution was not found and is required by the application
FAILED test/unit/test_iam_helper.py::test_read_auth_profile_raises_exception_if_profile_dne - ModuleNotFoundError: No module named 'botocore'
FAILED test/unit/test_iam_helper.py::test_read_auth_profile_loads_json_payload - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/test_iam_helper.py::test_read_auth_profile_invalid_json_payload_raises_exception - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/auth/test_aws_credentials_provider.py::test_refresh_uses_profile_if_present - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/auth/test_aws_credentials_provider.py::test_refresh_uses_credentials_if_present - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_request_error_should_fail[HTTPError] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_request_error_should_fail[Timeout] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_request_error_should_fail[TooManyRedirects] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_request_error_should_fail[RequestException] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_payload_is_correct - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_login_fails_should_fail[HTTPError] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_login_fails_should_fail[Timeout] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_login_fails_should_fail[TooManyRedirects] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_login_fails_should_fail[RequestException] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_saml_response_parse_fail_should_fail - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_adfs_credentials_provider.py::test_form_based_authentication_empty_saml_response_should_fail - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[okta_browser_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[azure_browser_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[jumpcloud_browser_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[ping_browser_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[jwt_google_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[jwt_azure_v2_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[okta_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[azure_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_credentials_providers.py::test_credential_provider_dne_should_fail[adfs_idp] - AssertionError: Regex pattern 'Invalid credentials provider WrongProvider' does not match "('communication error', ConnectionRefusedError(111, 'Connection refused'))".
FAILED test/unit/plugin/test_jwt_credentials_provider.py::test_refresh_no_jwt - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/plugin/test_jwt_credentials_provider.py::test_refresh_passes_jwt_to_boto3 - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_request_fails_should_fail[HTTPError] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_request_fails_should_fail[Timeout] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_request_fails_should_fail[TooManyRedirects] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_request_fails_should_fail[RequestException] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_valid_html_response_should_success - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_invalid_html_response_should_fail[<html></html>] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_invalid_html_response_should_fail[None] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_invalid_html_response_should_fail[] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_okta_credentials_provider.py::test_handle_saml_assertion_invalid_html_response_should_fail[<html><body><input name="RelayState" type="hidden" value=""/></body></html>] - ModuleNotFoundError: No module named 'bs4'
FAILED test/unit/plugin/test_saml_credentials_provider.py::test_refresh_get_saml_assertion_fails - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/plugin/test_saml_credentials_provider.py::test_refresh_saml_assertion_missing_role_should_fail - ModuleNotFoundError: No module named 'boto3'
FAILED test/unit/plugin/test_saml_credentials_provider.py::test_refresh_saml_assertion_passed_to_boto - ModuleNotFoundError: No module named 'boto3'
============================================================================================================================ 47 failed, 386 passed, 3 skipped in 7.76s =======================================================================================================================`


## License
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
