### PR TITLE
Release constraints on max version for pytz and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 scramp>=1.2.0,<1.5.0
-pytz>=2020.1,<2022.2
+pytz>=2020.1
 beautifulsoup4>=4.7.0,<5.0.0
 boto3>=1.9.201,<2.0.0
-requests>=2.23.0,<2.28.1
+requests>=2.23.0,<3.0.0
 lxml>=4.6.5
 botocore>=1.12.201,<2.0.0
 packaging


### PR DESCRIPTION
Fix https://github.com/aws/amazon-redshift-python-driver/issues/118

## Description
Don't force max version on dependencies for requests and pytz

## Motivation and Context
This will allow more people to use the library in the future when new release of requests and pytz are released
