### PR TITLE
fix(docs): change variable names from con to conn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,10 +103,10 @@ Enabling autocommit
 .. code-block:: py3
 
     # Make sure we're not in a transaction
-    con.rollback()
-    con.autocommit = True
-    con.run("VACUUM")
-    con.autocommit = False
+    conn.rollback()
+    conn.autocommit = True
+    conn.run("VACUUM")
+    conn.autocommit = False
 
 
 Configuring cursor paramstyle
@@ -237,7 +237,7 @@ Insert data stored in a ``pandas.DataFrame`` into an Amazon Redshift table
         ),
         columns=["bookname", "author‎"],
     )
-    with con.cursor() as cursor:
+    with conn.cursor() as cursor:
         cursor.write_dataframe(df, "book")
         cursor.execute("select * from book; ")
         result = cursor.fetchall()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have determined that there are variable name in the README that may mean the same thing. Specifically, `conn` and `con` are variable names that mean "return value of `redshift_connector .connect(...)`".

## Motivation and Context

This change lowers the cognitive load for users reading the document.

## Testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
