### PR TITLE
fix(cursor): Always return `pandas.DataFrame`

### DIFF
--- a/redshift_connector/cursor.py
+++ b/redshift_connector/cursor.py
@@ -493,7 +493,7 @@ class Cursor:
             else:
                 raise StopIteration()
 
-    def fetch_dataframe(self: "Cursor", num: typing.Optional[int] = None) -> typing.Optional["pandas.DataFrame"]:
+    def fetch_dataframe(self: "Cursor", num: typing.Optional[int] = None) -> "pandas.DataFrame":
         """
         Fetches a user defined number of rows of a query result as a :class:`pandas.DataFrame`.
 
@@ -503,7 +503,7 @@ class Cursor:
 
         Returns
         -------
-        A `pandas.DataFrame` containing field values making up a row. A column label, derived from the row description of the table, is provided.:typing.Optional["pandas.Dataframe"]
+        A `pandas.DataFrame` containing field values making up a row. A column label, derived from the row description of the table, is provided. : "pandas.Dataframe"
         """
         try:
             import pandas
@@ -522,8 +522,7 @@ class Cursor:
             fetcheddata = self.fetchall()
 
         result: typing.List = [tuple(column for column in rows) for rows in fetcheddata]
-        if len(result) == 0:
-            return None
+
         return pandas.DataFrame(result, columns=columns)
 
     def __is_valid_table(self: "Cursor", table: str) -> bool:

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -47,7 +47,7 @@ def test_fetch_dataframe_no_results(mocker):
     mocker.patch("redshift_connector.Cursor._getDescription", return_value=["test"])
     mocker.patch("redshift_connector.Cursor.__next__", side_effect=StopIteration("mocked end"))
 
-    assert mock_cursor.fetch_dataframe(1) is None
+    assert mock_cursor.fetch_dataframe(1).size == 0
 
 
 def test_raw_connection_property_warns():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently `cursor.fetch_dataframe()` returns a `None` object when there are no results returned by the query, this is also backed up by the type hint `typing.Optional["pandas.DataFrame"]` [on this line](https://github.com/aws/amazon-redshift-python-driver/blob/80c416bde2192ebce23e075247937fa12bc8ccfa/redshift_connector/cursor.py#L496). My changes makes sure that `cursor.fetch_dataframe()` always returns a `pandas.DataFrame` even if if the DataFrame is empty (but with column headers)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Without reading too deeply into the source code, when a user calls `cursor.fetch_dataframe()` they expect a `pandas.DataFrame` to be returned, but there is an case when the SQL query returns no results then `fetch_dataframe` returns `None` instead of the expected empty DataFrame. This causes issues for users who migrate away from things like `psycopg2` and manual creation of DataFrames, they would expect to test empty datasets not by `df is None` but using the [`.empty`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.empty.html) attribute or even:
```python
df = cursor.fetch_dataframe()
if df:
    print("DataFrame has data")
else:
    print("DataFrame is empty")
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
