### PR TITLE
Raise OperationalError for socket timeouts

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -658,7 +658,10 @@ class Connection:
                 self._usock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         except socket.error as e:
             self._usock.close()
-            raise InterfaceError("communication error", e)
+            if socket.timeout:
+                raise OperationalError("connection time out", e)
+            else:
+                raise InterfaceError("communication error", e)
         self._flush: typing.Callable = self._sock.flush
         self._read: typing.Callable = self._sock.read
         self._write: typing.Callable = self._sock.write


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Map socket timeout errors to OperationalError instead of InterfaceError
## Description
<!--- Describe your changes in detail -->
socket.timeouts are a subclass within socket.error, and socket.error is classified as InterfaceError. Hence socket.timeouts gets classified as InterfaceError as well. This change will map socket.timeouts alone to OperationalError, where other exceptions within socket.errors will remain unchanged.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [ ] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
