### PR TITLE
Raise OperationalError for socket timeouts

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -656,12 +656,14 @@ class Connection:
             self._sock: typing.Optional[typing.BinaryIO] = self._usock.makefile(mode="rwb")
             if tcp_keepalive:
                 self._usock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+        except socket.timeout as timeout_error:
+            self._usock.close()
+            raise OperationalError("connection time out", timeout_error)
+
         except socket.error as e:
             self._usock.close()
-            if socket.timeout:
-                raise OperationalError("connection time out", e)
-            else:
-                raise InterfaceError("communication error", e)
+            raise InterfaceError("communication error", e)
         self._flush: typing.Callable = self._sock.flush
         self._read: typing.Callable = self._sock.read
         self._write: typing.Callable = self._sock.write

--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -658,7 +658,10 @@ class Connection:
                 self._usock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         except socket.error as e:
             self._usock.close()
-            raise InterfaceError("communication error", e)
+            if socket.timeout:
+                raise OperationalError("connection time out", e)
+            else:
+                raise InterfaceError("communication error", e)
         self._flush: typing.Callable = self._sock.flush
         self._read: typing.Callable = self._sock.read
         self._write: typing.Callable = self._sock.write

--- a/test/integration/test_connection.py
+++ b/test/integration/test_connection.py
@@ -307,3 +307,9 @@ def test_execute_do_parsing_bind_params_when_exist(mocker, db_kwargs, sql, args)
     with redshift_connector.connect(**db_kwargs) as conn:
         conn.cursor().execute(sql, args)
     assert convert_paramstyle_spy.called
+
+def test_socket_timeout(db_kwargs):
+    db_kwargs["timeout"] = 0
+
+    with pytest.raises(redshift_connector.OperationalError):
+        redshift_connector.connect(**db_kwargs)

--- a/test/integration/test_connection.py
+++ b/test/integration/test_connection.py
@@ -311,5 +311,5 @@ def test_execute_do_parsing_bind_params_when_exist(mocker, db_kwargs, sql, args)
 def test_socket_timeout(db_kwargs):
     db_kwargs["timeout"] = 0
 
-    with pytest.raises(redshift_connector.OperationalError):
+    with pytest.raises(redshift_connector.InterfaceError):
         redshift_connector.connect(**db_kwargs)

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -333,7 +333,7 @@ def test_client_os_version_is_not_present():
         assert mock_connection.client_os_version == "unknown"
 
 def test_socket_timeout_error():
-    with mock.patch('socket.socket.bind') as mock_socket:
-        mock_socket.side_effect = socket.timeout
+    with mock.patch('socket.socket.connect') as mock_socket:
+        mock_socket.side_effect = (socket.timeout)
         with pytest.raises(OperationalError):
             Connection(user='mock_user', password='mock_password', host='localhost', port=8080, database='mocked')

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -2,6 +2,8 @@ import typing
 from collections import deque
 from decimal import Decimal
 from unittest.mock import patch
+import socket
+from unittest import mock
 
 import pytest  # type: ignore
 
@@ -12,6 +14,7 @@ from redshift_connector import (
     IntegrityError,
     InterfaceError,
     ProgrammingError,
+    OperationalError
 )
 from redshift_connector.config import (
     ClientProtocolVersion,
@@ -328,3 +331,9 @@ def test_client_os_version_is_not_present():
 
     with patch("platform.platform", side_effect=Exception("not for you")):
         assert mock_connection.client_os_version == "unknown"
+
+def test_socket_timeout_error():
+    with mock.patch('socket.socket.bind') as mock_socket:
+        mock_socket.side_effect = socket.timeout
+        with pytest.raises(OperationalError):
+            Connection(user='mock_user', password='mock_password', host='localhost', port=8080, database='mocked')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Map socket timeout errors to OperationalError instead of InterfaceError


## Description
<!--- Describe your changes in detail -->
socket.timeouts are a subclass within socket.error, and socket.error is classified as InterfaceError. Hence socket.timeouts gets classified as InterfaceError as well. This change will map socket.timeouts alone to OperationalError, where other exceptions within socket.errors will remain unchanged.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This PR resolves this [issue](https://github.com/dbt-labs/dbt-redshift/issues/556)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Conducted manual testing - hit timeout and received the below error message: 
```
    raise OperationalError("connection time out", e)
redshift_connector.error.OperationalError: ('connection time out', TimeoutError(60, 'Operation timed out'))

```

Added unit test and integration test as well.

## Screenshots (if appropriate)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
