### PR TITLE
fix(connection): unpack_from error caused by network issues

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -2003,7 +2003,22 @@ class Connection:
         code = self.error = None
 
         while code != READY_FOR_QUERY:
-            code, data_len = ci_unpack(self._read(5))
+            buffer = self._read(5)
+
+            if len(buffer) == 0:
+                if self._usock.timeout is not None:
+                    raise InterfaceError(
+                        "BrokenPipe: server socket closed. We noticed a timeout is set for this connection. Consider "
+                        "raising the timeout or defaulting timeout to none."
+                    )
+                else:
+                    raise InterfaceError(
+                        "BrokenPipe: server socket closed. Please check that client side networking configurations such "
+                        "as Proxies, firewalls, VPN, etc. are not affecting your network connection."
+                    )
+
+            code, data_len = ci_unpack(buffer)
+
             self.message_types[code](self._read(data_len - 4), cursor)
 
         if self.error is not None:
@@ -2024,7 +2039,20 @@ class Connection:
         """
         code = self.error = None
         # read 5 bytes of message firstly
-        code, data_len = ci_unpack(self._read(5))
+        buffer = self._read(5)
+        if len(buffer) == 0:
+            if self._usock.timeout is not None:
+                raise InterfaceError(
+                    "BrokenPipe: server socket closed. We noticed a timeout is set for this connection. Consider "
+                    "raising the timeout or defaulting timeout to none."
+                )
+            else:
+                raise InterfaceError(
+                    "BrokenPipe: server socket closed. Please check that client side networking configurations such "
+                    "as Proxies, firewalls, VPN, etc. are not affecting your network connection."
+                )
+
+        code, data_len = ci_unpack(buffer)
 
         while True:
             if code == READY_FOR_QUERY:

--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -738,7 +738,21 @@ class Connection:
             # Each time will read 5 bytes, the first byte, the code, inform the type of message
             # following 4 bytes inform the message's length
             # then can use this length to minus 4 to get the real data.
-            code, data_len = ci_unpack(self._read(5))
+            buffer = self._read(5)
+
+            if len(buffer) == 0:
+                if self._usock.timeout is not None:
+                    raise InterfaceError(
+                        "BrokenPipe: server socket closed. We noticed a timeout is set for this connection. Consider "
+                        "raising the timeout or defaulting timeout to none."
+                    )
+                else:
+                    raise InterfaceError(
+                        "BrokenPipe: server socket closed. Please check that client side networking configurations such "
+                        "as Proxies, firewalls, VPN, etc. are not affecting your network connection."
+                    )
+
+            code, data_len = ci_unpack(buffer)
             self.message_types[code](self._read(data_len - 4), None)
         if self.error is not None:
             raise self.error

--- a/test/integration/test_connection.py
+++ b/test/integration/test_connection.py
@@ -2,9 +2,7 @@ import configparser
 import logging
 import os
 import random
-import socket
 import string
-import struct
 import sys
 
 import pytest  # type: ignore
@@ -178,10 +176,31 @@ def test_broken_pipe(con, db_kwargs):
             pid1 = cur1.fetchone()[0]
 
             cur2.execute("select pg_terminate_backend(%s)", (pid1,))
-            try:
+            with pytest.raises(
+                redshift_connector.InterfaceError,
+                match="BrokenPipe: server socket closed. Please check that client side networking configurations such "
+                "as Proxies, firewalls, VPN, etc. are not affecting your network connection.",
+            ):
                 cur1.execute("select 1")
-            except Exception as e:
-                assert isinstance(e, (socket.error, struct.error))
+
+
+# case 2: same connector configuration, but should throw an error since the timeout is set,
+def test_broken_pipe_timeout(con, db_kwargs):
+    db_kwargs["timeout"] = 60
+    with redshift_connector.connect(**db_kwargs) as db1:
+        with db1.cursor() as cur1, con.cursor() as cur2:
+            print(db1._usock.timeout)
+            cur1.execute("select pg_backend_pid()")
+            pid1 = cur1.fetchone()[0]
+
+            cur2.execute("select pg_terminate_backend(%s)", (pid1,))
+            with pytest.raises(
+                redshift_connector.InterfaceError,
+                match="BrokenPipe: server socket closed. We noticed a timeout is "
+                "set for this connection. Consider raising the timeout or "
+                "defaulting timeout to none.",
+            ):
+                cur1.execute("select 1")
 
 
 def test_application_name_integer(db_kwargs):

--- a/test/unit/test_connection.py
+++ b/test/unit/test_connection.py
@@ -1,9 +1,9 @@
+import socket
 import typing
 from collections import deque
 from decimal import Decimal
-from unittest.mock import patch
-import socket
 from unittest import mock
+from unittest.mock import patch
 
 import pytest  # type: ignore
 
@@ -13,8 +13,8 @@ from redshift_connector import (
     Error,
     IntegrityError,
     InterfaceError,
+    OperationalError,
     ProgrammingError,
-    OperationalError
 )
 from redshift_connector.config import (
     ClientProtocolVersion,
@@ -28,7 +28,9 @@ from redshift_connector.config import (
 from redshift_connector.utils.type_utils import py_types as PY_TYPES
 from redshift_connector.utils.type_utils import redshift_types as REDSHIFT_TYPES
 
-test_error_responses_data: typing.List[typing.Tuple[bytes, typing.Dict, typing.Type[Error]]] = [
+test_error_responses_data: typing.List[
+    typing.Tuple[bytes, typing.Dict, typing.Type[Error]]
+] = [
     (
         (
             b"SERROR\x00"
@@ -337,3 +339,90 @@ def test_socket_timeout_error():
         mock_socket.side_effect = (socket.timeout)
         with pytest.raises(OperationalError):
             Connection(user='mock_user', password='mock_password', host='localhost', port=8080, database='mocked')
+
+def mock_read(*args, **kwargs):
+    return b""
+
+
+def test_handle_messages_broken_pipe_blocking():
+    # mock the connection and mock the read attribute
+    mock_connection: Connection = Connection.__new__(Connection)
+    mock_connection._read = mock_read
+
+    # we only need to mock the raw socket
+    mock_usock = mock.Mock()
+    mock_usock.timeout = None
+    mock_connection._usock = mock_usock
+
+    mock_cursor: Cursor = Cursor.__new__(Cursor)
+    mock_cursor.ps = None
+
+    with pytest.raises(
+        InterfaceError,
+        match="BrokenPipe: server socket closed. Please check that client side networking configurations such "
+        "as Proxies, firewalls, VPN, etc. are not affecting your network connection.",
+    ):
+        mock_connection.handle_messages(mock_cursor)
+
+
+def test_handle_messages_broken_pipe_timeout():
+    # mock the connection and mock the read attribute
+    mock_connection: Connection = Connection.__new__(Connection)
+    mock_connection._read = mock_read
+
+    # we only need to mock the raw socket
+    mock_usock = mock.Mock()
+    mock_usock.timeout = 47
+    mock_connection._usock = mock_usock
+
+    mock_cursor: Cursor = Cursor.__new__(Cursor)
+    mock_cursor.ps = None
+
+    with pytest.raises(
+        InterfaceError,
+        match="BrokenPipe: server socket closed. We noticed a timeout is set for this connection. Consider "
+        "raising the timeout or defaulting timeout to none.",
+    ):
+        mock_connection.handle_messages(mock_cursor)
+
+
+def test_handle_messages_merge_socket_read_broken_pipe_blocking():
+    # mock the connection and mock the read attribute
+    mock_connection: Connection = Connection.__new__(Connection)
+    mock_connection._read = mock_read
+
+    # we only need to mock the raw socket
+    mock_usock = mock.Mock()
+    mock_usock.timeout = None
+    mock_connection._usock = mock_usock
+
+    mock_cursor: Cursor = Cursor.__new__(Cursor)
+    mock_cursor.ps = None
+
+    with pytest.raises(
+        InterfaceError,
+        match="BrokenPipe: server socket closed. Please check that client side networking configurations such "
+        "as Proxies, firewalls, VPN, etc. are not affecting your network connection.",
+    ):
+        mock_connection.handle_messages_merge_socket_read(mock_cursor)
+
+
+def test_handle_messages_merge_socket_read_broken_pipe_timeout():
+    # mock the connection and mock the read attribute
+    mock_connection: Connection = Connection.__new__(Connection)
+    mock_connection._read = mock_read
+
+    # we only need to mock the raw socket
+    mock_usock = mock.Mock()
+    mock_usock.timeout = 47
+    mock_connection._usock = mock_usock
+
+    mock_cursor: Cursor = Cursor.__new__(Cursor)
+    mock_cursor.ps = None
+
+    with pytest.raises(
+        InterfaceError,
+        match="BrokenPipe: server socket closed. We noticed a timeout is set for this connection. Consider "
+        "raising the timeout or defaulting timeout to none.",
+    ):
+        mock_connection.handle_messages_merge_socket_read(mock_cursor)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* add error msg for timeout + network config issues
* add integration tests for error
* add unit tests for error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Problem: When the server side socket closes due to the network issues, redshift-connector raises an unpack_from error that is confusing and misleading to users. 
Now, when the server side socket closes due to network issues, redshift-connector will raise the error suggesting users to double check their client-side networking configurations, and if they set a timeout for their connection, will ask them to raise it or use None as default.

<!--- If it fixes an open issue, please link to the issue here -->
The fix address this [issue](https://github.com/aws/amazon-redshift-python-driver/issues/164). (due to network issues)

## Testing
<!--- Please describe in detail how you tested your changes -->
Wrote unit and integration tests.
Ran manual tests using default timeout and manually setting timeout:
### Deterministic example:
```
conn = redshift_connector.connect(dbkwargs)
conn2 = redshift_connector.connect(dbkwargs)
res = conn2.run("select pg_backend_pid()")
pid1 = res[0][0]

conn.run("select pg_terminate_backend(:v)", v=pid1)
conn2.run("select 1") 
```
### Nondeterministic example:
```
conn = redshift_connector.connect(dbkwargs)
cursor = conn.cursor()
try:
   for i in range(100):
      print(f"Connection is open. Waiting... {i} round")
      time.sleep(33)
      cursor.execute("select * from svv_all_columns")
     time.sleep(17)
          
except Exception as e:
   raise e
finally:
   cursor.close()
```
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
