### PR TITLE
Fix: force timeouts to integer types

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -618,7 +618,7 @@ class Connection:
                 raise ProgrammingError("one of host or unix_sock must be provided")
             if timeout is not None:
                 _logger.debug("set socket timeout=%s", timeout)
-                self._usock.settimeout(timeout)
+                self._usock.settimeout(int(timeout))
 
             if unix_sock is None and host is not None:
                 hostport: typing.Tuple[str, int] = Connection.__get_host_address_info(host, port)

--- a/redshift_connector/plugin/browser_azure_oauth2_credentials_provider.py
+++ b/redshift_connector/plugin/browser_azure_oauth2_credentials_provider.py
@@ -68,7 +68,7 @@ class BrowserAzureOAuth2CredentialsProvider(JwtCredentialsProvider):
             BrowserAzureOAuth2CredentialsProvider.handle_missing_required_property("idp_tenant")
         if not self.client_id:
             BrowserAzureOAuth2CredentialsProvider.handle_missing_required_property("client_id")
-        if not self.idp_response_timeout or self.idp_response_timeout < 10:
+        if not self.idp_response_timeout or int(self.idp_response_timeout) < 10:
             BrowserAzureOAuth2CredentialsProvider.handle_invalid_property_value(
                 "idp_response_timeout", "Must be 10 seconds or greater"
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
literally just 2 `int()` casts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Since sqlalchemy (and other packages) force url parameters to be passed as strings to redshift_connector, we can run into basic and avoidable issues from this package when connecting to Redshift via SQLAlchemy via the `BrowserAzureOAuth2CredentialsProvider` method. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include code snippits, details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built package, connected, fixed the bug.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [ ] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
