### PR TITLE
BugFix: Add support for both IPv4 and IPv6 connections

### DIFF
--- a/redshift_connector/core.py
+++ b/redshift_connector/core.py
@@ -395,19 +395,28 @@ class Connection:
             os_version = "unknown"
         return os_version
 
+
     @staticmethod
-    def __get_host_address_info(host: str, port: int):
+    def __get_host_address_info(host: str, port: int) -> typing.Tuple:
         """
-        Returns IPv4 address and port given a host name and port
+        Returns address and port given a host name and port, supports both IPv4 and IPv6.
         """
-        # https://docs.python.org/3/library/socket.html#socket.getaddrinfo
-        response = socket.getaddrinfo(host=host, port=port, family=socket.AF_INET)
+        response = socket.getaddrinfo(host=host, port=port)
         _logger.debug("getaddrinfo response %s", response)
 
         if not response:
-            raise InterfaceError("Unable to determine ip for host %s port %s", host, port)
+            raise InterfaceError(
+                "Unable to determine IP for host %s port %s" % (host, port)
+            )
 
-        return response[0][4]
+        for res in response:
+            af, socktype, proto, canonname, sockaddr = res
+            if af == socket.AF_INET or af == socket.AF_INET6:
+                return sockaddr, af
+
+        raise InterfaceError(
+            "No suitable address found for host %s port %s" % (host, port)
+        )
 
     def __init__(
         self: "Connection",
@@ -623,8 +632,13 @@ class Connection:
                 self._usock.settimeout(timeout)
 
             if unix_sock is None and host is not None:
-                hostport: typing.Tuple[str, int] = Connection.__get_host_address_info(host, port)
+                # hostport: typing.Tuple[str, int] = Connection.__get_host_address_info(host, port)
+                # _logger.debug("Attempting to create connection socket with address %s", hostport)
+                # self._usock.connect(hostport)
+                hostport, address_family = Connection.__get_host_address_info(host, port)
                 _logger.debug("Attempting to create connection socket with address %s", hostport)
+
+                self._usock = socket.socket(address_family, socket.SOCK_STREAM)
                 self._usock.connect(hostport)
             elif unix_sock is not None:
                 _logger.debug("connecting to socket with unix socket")


### PR DESCRIPTION
## Description

At my company we started using VPN that only works over IPv6. Since that we started seeing below errors when connecting:

```
 08:57:16 Encountered an error: Database Error ('communication error', gaierror(8, 'nodename nor servname provided, or not known'))
```

Mainly played around and used chat GPT to make the above changes, so please let me know if they look fine with you.

Details

- Updated the method `__get_host_address_info` to support returning both IPv4 and IPv6 address information.
  - The method now returns a tuple containing the address (sockaddr) and the address family (af).
  - This allows the caller to handle the address appropriately based on its type.

- Modified the initializer to handle both IPv4 and IPv6 addresses.
  - The method `__get_host_address_info` is called and its response is unpacked into `hostport` and `address_family`.
  - Created a socket using the correct address family (`AF_INET` for IPv4 and `AF_INET6` for IPv6).
  - Ensured that the socket is connected using the `hostport` which now correctly handles both address types.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing

I've tried to connect both on new and old VPN and this snipped doesn't return an error anymore:

```
password = os.environ.get("REDSHIFT_PASSWORD")
user = os.environ.get("REDSHIFT_USER")
databse = os.environ.get("REDSHIFT_DATABASE")
host = os.environ.get("REDSHIFT_HOST")

conn = redshift_connector.connect(
    host=host,
    database=databse,
    user=user,
    password=password,
)

cursor: redshift_connector.Cursor = conn.cursor()
cursor.execute("select 1")
result: tuple = cursor.fetchall()
print(result)
cursor.close()
```

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [ ] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
