### PR TITLE
fix(cursor, fetch_dataframe): use column names in cursor's description as is

### DIFF
--- a/redshift_connector/cursor.py
+++ b/redshift_connector/cursor.py
@@ -523,7 +523,7 @@ class Cursor:
 
         columns: typing.Optional[typing.List[typing.Union[str, bytes]]] = None
         try:
-            columns = [column[0].lower() for column in self.description]
+            columns = [column[0] for column in self.description]
         except:
             warn("No row description was found. pandas dataframe will be missing column labels.", stacklevel=2)
 

--- a/test/unit/test_cursor.py
+++ b/test/unit/test_cursor.py
@@ -51,6 +51,23 @@ def test_fetch_dataframe_no_results(mocker) -> None:
     assert mock_cursor.fetch_dataframe(1).size == 0
 
 
+@pandas_only
+def test_fetch_dataframe_respects_case_sensitivity(mocker) -> None:
+    import pandas as pd
+
+    mock_cursor: Cursor = Cursor.__new__(Cursor)
+    mocker.patch(
+        "redshift_connector.Cursor._getDescription",
+        return_value=[("C", 23, None, None, None, None, None)],
+    )
+    mocker.patch("redshift_connector.Cursor.__next__", side_effect=StopIteration("mocked end"))
+
+    df = mock_cursor.fetch_dataframe()
+
+    assert df.size == 0
+    assert df.columns.to_list() == ["C"]
+
+
 def test_raw_connection_property_warns() -> None:
     mock_cursor: Cursor = Cursor.__new__(Cursor)
     mock_cursor._c = Connection.__new__(Connection)


### PR DESCRIPTION
Previously, the `Cursor.fetch_dataframe` method lowercased column names preemptively, thus not respecting the [case-sensitivity configuration value](https://docs.aws.amazon.com/redshift/latest/dg/r_enable_case_sensitive_identifier.html). This could lead to issues, when e.g. two different columns resolved to the same name when lowercased.

This PR fixes the issue by ensuring the resulting `DataFrame`'s columns are the same as the ones in the cursor's `description` attribute, thus making the driver match Redshift's behavior.

## Motivation and Context
Fixes #238 

## Testing
Implemented a unit test that demonstrates how `fetch_dataframe` preserves the column names as they appear in the cursor's `description` attribute.

After making the change, I ran `python -m pytest test/unit` in a fresh environment and observed all tests succeeding:

```
922 passed, 11 warnings in 3.26s
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] I have run all unit tests using `pytest test/unit` and they are passing.

## License
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
