### PR TITLE
Master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytz>=2020.1
 beautifulsoup4>=4.7.0,<5.0.0
 boto3>=1.9.201,<2.0.0
 requests>=2.23.0,<3.0.0
-lxml>=4.6.5
+lxml>=4.6.5,,<5.4.0
 botocore>=1.12.201,<2.0.0
 packaging
 setuptools


### PR DESCRIPTION
Added max supported version of lxml

After the recent release of lxml connector started to throw error, so added a max allowed version

## Motivation and Context
For best codes to not fail suddenly, this is a best practice

https://github.com/aws/amazon-redshift-python-driver/issues/263
 
