### PR TITLE
Grammar improvements to logging messages in ping provider

### DIFF
--- a/redshift_connector/plugin/ping_credentials_provider.py
+++ b/redshift_connector/plugin/ping_credentials_provider.py
@@ -68,11 +68,11 @@ class PingCredentialsProvider(SamlCredentialsProvider):
                 _logger.debug(exec_msg)
                 raise InterfaceError(exec_msg) from e
             except requests.exceptions.TooManyRedirects as e:
-                exec_msg = "A error occurred when requesting Ping IdP login page. Please verify connection properties are correct."
+                exec_msg = "An error occurred when requesting Ping IdP login page. Please verify connection properties are correct."
                 _logger.debug(exec_msg)
                 raise InterfaceError(exec_msg) from e
             except requests.exceptions.RequestException as e:
-                exec_msg = "A unknown error occurred when requesting Ping IdP login page. Please verify connection properties are correct."
+                exec_msg = "An unknown error occurred when requesting Ping IdP login page. Please verify connection properties are correct."
                 _logger.debug(exec_msg)
                 raise InterfaceError(exec_msg) from e
 
@@ -180,7 +180,7 @@ class PingCredentialsProvider(SamlCredentialsProvider):
                     assertion = inputtag.get("value")
 
             if assertion == "":
-                exec_msg = "Failed to retrieve SAMLAssertion. A input tag named SAMLResponse was not identified in the Ping IdP authentication response"
+                exec_msg = "Failed to retrieve SAMLAssertion. An input tag named SAMLResponse was not identified in the Ping IdP authentication response"
                 _logger.debug(exec_msg)
                 raise InterfaceError(exec_msg)
 

--- a/redshift_connector/plugin/saml_credentials_provider.py
+++ b/redshift_connector/plugin/saml_credentials_provider.py
@@ -106,7 +106,7 @@ class SamlCredentialsProvider(IdpCredentialsProvider):
         _logger.debug("decoded SAML assertion into xml format")
         soup = bs4.BeautifulSoup(doc, "xml")
         attrs = soup.findAll("Attribute")
-        # extract RoleArn adn PrincipleArn from SAML assertion
+        # extract RoleArn and PrincipleArn from SAML assertion
         role_pattern = re.compile(r"arn:aws:iam::\d*:role/\S+")
         provider_pattern = re.compile(r"arn:aws:iam::\d*:saml-provider/\S+")
         roles: typing.Dict[str, str] = {}


### PR DESCRIPTION
## Motivation and Context
I got the exception today and I want to improve the grammar

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x ] Local run of `./build.sh` succeeds
- [ ] Code changes have been run against the repository's pre-commit hooks
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ x] I have run all unit tests using `pytest test/unit` and they are passing.
<!-- Please note: Our developers will work with you to ensure your changes pass our internal integration test suite.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
