### PR TITLE
fix: raise lxml upper bound to <7.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytz>=2020.1
 beautifulsoup4>=4.13.5,<5.0.0
 boto3>=1.42.22,<2.0.0
 requests>=2.23.0,<3.0.0
-lxml>=4.6.5,<=6.0.2
+lxml>=4.6.5,<7.0.0
 botocore>=1.12.201,<2.0.0
 packaging
 setuptools


### PR DESCRIPTION
## Description

Raises the `lxml` upper bound in `requirements.txt` from `<=6.0.2` to `<7.0.0`.

## Motivation and Context

lxml 6.1.0 addresses CVE-2026-41066 (XXE via changed `resolve_entities` default in `iterparse`/`ETCompatXMLParser`). The current `<=6.0.2` cap prevents downstream users from taking that security fix.

lxml 6.0 support was already validated in this repo (see `TestLxmlCurlyBraceCompatibility` in `test/unit/plugin/test_adfs_credentials_provider.py`). lxml 6.1.0 introduces no breaking changes for this package because all lxml usage flows through BeautifulSoup4, which abstracts the parser API entirely:

- `adfs_credentials_provider.py` — `bs4.BeautifulSoup(response.text, features="lxml")`
- `saml_credentials_provider.py` — `bs4.BeautifulSoup(doc, "xml")`
- `ping_credentials_provider.py` — `bs4.BeautifulSoup(response.text)`

None of the removed or changed lxml 6.x APIs are called directly (`setElementClassLookup`, `apply`, `evaluate`, `MemDebug`, smart-string `text_content`, `iterparse` entity resolution default). BeautifulSoup4 isolates all of that. Raising the cap to `<7.0.0` unblocks the upgrade path while matching the approach already taken for lxml 6.0.

## Testing

No code paths were changed — only the declared version constraint. The existing `TestLxmlCurlyBraceCompatibility` test class already covers lxml 6.x + BeautifulSoup4 compatibility for the ADFS provider. All existing unit tests pass unchanged with lxml 6.1.0 installed.

## Screenshots

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Local run of `./build.sh` succeeds
- [x] Code changes have been run against the repository's pre-commit hooks (`pre-commit run --files requirements.txt` — clean; pre-existing hook failures exist in untouched files)
- [x] Commit messages follow [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read the **README** document
- [x] I have added tests to cover my changes (no code was changed; existing `TestLxmlCurlyBraceCompatibility` covers lxml 6.x compatibility)
- [x] I have run all unit tests using `pytest test/unit` and they are passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
